### PR TITLE
Add conversion of $ReadOnly util to Readonly

### DIFF
--- a/src/plugin/__tests__/__fixtures__/types/utility/readonly/input.js
+++ b/src/plugin/__tests__/__fixtures__/types/utility/readonly/input.js
@@ -1,0 +1,4 @@
+// @flow
+type ReadOnlyObj = $ReadOnly<{
+  key: any,
+}>;

--- a/src/plugin/__tests__/__fixtures__/types/utility/readonly/output.ts
+++ b/src/plugin/__tests__/__fixtures__/types/utility/readonly/output.ts
@@ -1,0 +1,3 @@
+type ReadOnlyObj = Readonly<{
+  key: any;
+}>;

--- a/src/plugin/converters/type-annotation.ts
+++ b/src/plugin/converters/type-annotation.ts
@@ -28,6 +28,7 @@ import {
   convertNonMaybeTypeUtil,
   convertPropertyTypeUtil,
   convertReadOnlyArrayUtil,
+  convertReadOnlyUtil,
   convertRestUtil,
   convertShapeUtil,
 } from './utility';
@@ -97,6 +98,9 @@ export function convertGenericTypeAnnotation(
 
         case 'Class':
           return convertClassUtil(typeParameters, path);
+
+        case '$ReadOnly':
+          return convertReadOnlyUtil(typeParameters);
 
         // Unsupported utility types
         case '$ObjMap':

--- a/src/plugin/converters/utility.ts
+++ b/src/plugin/converters/utility.ts
@@ -131,3 +131,6 @@ export const convertRestUtil: UtilConvertor<TSTypeReference> = typeParameters =>
 
 export const convertShapeUtil: UtilConvertor<TSTypeReference> = typeParameters =>
   tsTypeReference(identifier('Partial'), typeParameters);
+
+export const convertReadOnlyUtil: UtilConvertor<TSTypeReference> = typeParameters =>
+  tsTypeReference(identifier('Readonly'), typeParameters);


### PR DESCRIPTION
Flow's [$ReadOnly](https://flow.org/en/docs/types/utilities/#toc-readonly) utility type has an equivalent TS counterpart [Readonly](https://www.typescriptlang.org/docs/handbook/utility-types.html#readonlyt) so this conversion is straightforward like other utility types.