### PR TITLE
Strip type in export statements

### DIFF
--- a/src/plugin/__tests__/__fixtures__/types/modules/input.js
+++ b/src/plugin/__tests__/__fixtures__/types/modules/input.js
@@ -38,3 +38,6 @@ export const exportedConstMaybe2: ?string = 'string';
 export function exportedFunction2(x: number): void {}
 export interface ExportedInterface2 {}
 export type ExportedAliasType2<T> = $ReadOnlyArray<T>;
+
+type NamedExport = string;
+export type { NamedExport };

--- a/src/plugin/__tests__/__fixtures__/types/modules/output.ts
+++ b/src/plugin/__tests__/__fixtures__/types/modules/output.ts
@@ -38,3 +38,6 @@ export const exportedConstMaybe2: string | null | undefined = 'string';
 export function exportedFunction2(x: number): void {}
 export interface ExportedInterface2 {}
 export type ExportedAliasType2<T> = ReadonlyArray<T>;
+
+type NamedExport = string;
+export { NamedExport };

--- a/src/plugin/converters/module.ts
+++ b/src/plugin/converters/module.ts
@@ -5,6 +5,9 @@ import {
   isFlowType,
   isImportDeclaration,
   typeofTypeAnnotation,
+  ExportDeclaration,
+  isExportNamedDeclaration,
+  isFlow,
 } from '@babel/types';
 
 import { convertReactImports } from './react/imports';
@@ -45,6 +48,18 @@ export function convertImportSpecifier(path: NodePath<ImportSpecifier>): ImportS
 
   // Strip Flow's `type` and `typeof` keywords in import declarations.
   path.node.importKind = null;
+
+  return path.node;
+}
+
+export function convertExportDeclaration(path: NodePath<ExportDeclaration>): ExportDeclaration {
+  // Strip Flow's `type` keyword in export declarations.
+  const { node } = path;
+  if (isExportNamedDeclaration(node)) {
+    if (node.exportKind === 'type' && !isFlow(node.declaration)) {
+      node.exportKind = null;
+    }
+  }
 
   return path.node;
 }

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -7,6 +7,7 @@ import {
   importSpecifierVisitor,
   importDeclarationVisitor,
   functionVisitor,
+  exportDeclarationVisitor,
 } from './visitors/base';
 import { flowVisitor } from './visitors/flow';
 import { jsxVisitor } from './visitors/jsx';
@@ -25,6 +26,7 @@ const reflowPlugin = {
     FunctionExpression: functionVisitor,
     ImportDeclaration: importDeclarationVisitor,
     ImportSpecifier: importSpecifierVisitor,
+    ExportDeclaration: exportDeclarationVisitor,
     Flow: flowVisitor,
     JSX: jsxVisitor,
     Program: programVisitor,

--- a/src/plugin/visitors/base.ts
+++ b/src/plugin/visitors/base.ts
@@ -5,11 +5,16 @@ import {
   FunctionExpression,
   ImportDeclaration,
   ImportSpecifier,
+  ExportDeclaration,
 } from '@babel/types';
 
 import { VisitorFunction, ConverterState } from '../types';
 import { convertClassDeclaration } from '../converters/class';
-import { convertImportDeclaration, convertImportSpecifier } from '../converters/module';
+import {
+  convertImportDeclaration,
+  convertImportSpecifier,
+  convertExportDeclaration,
+} from '../converters/module';
 import { convertOptionalFunctionParameters } from '../converters/function';
 
 export type BaseVisitorNodes = ArrowFunctionExpression &
@@ -35,4 +40,8 @@ export const importDeclarationVisitor: VisitorFunction<ImportDeclaration> = path
 
 export const importSpecifierVisitor: VisitorFunction<ImportSpecifier> = path => {
   path.replaceWith(convertImportSpecifier(path));
+};
+
+export const exportDeclarationVisitor: VisitorFunction<ExportDeclaration> = path => {
+  path.replaceWith(convertExportDeclaration(path));
 };


### PR DESCRIPTION
Currently the code like `export type {SomeType}` doesn't get transformed producing invalid TS code. `export type` with declarations should remain unaffected.